### PR TITLE
feat: Add saas-template octo-sts policy

### DIFF
--- a/.github/chainguard/GitlabSaasTemplate.yaml
+++ b/.github/chainguard/GitlabSaasTemplate.yaml
@@ -1,0 +1,21 @@
+# Allows our saas-template to pull its required components
+
+issuer: https://gitlab.shopware.com
+subject_pattern: "project_path:shopware/6/product/saas:ref_type:branch:ref:.*"
+
+permissions:
+  contents: read
+
+repositories:
+  - shopware-private
+  - Rufus
+  - SwagCommercial
+  - SwagDynamicAccess
+  - SwagPublisher
+  - SwagCmsExtensions
+  - SwagCustomizedProducts
+  - SwagMigrationAssistant
+  - SwagLanguagePack
+  - SwagPayPal
+  - SwagSocialShopping
+  - swagdigitalsalesrooms


### PR DESCRIPTION
Allow the saas-template to issue a temporarily github token through octo-sts