### PR TITLE
feat: add read access for org repos to terraform modules

### DIFF
--- a/.github/chainguard/AppsServicesTerraformModules.sts.yaml
+++ b/.github/chainguard/AppsServicesTerraformModules.sts.yaml
@@ -1,0 +1,14 @@
+# Allows repositories in shopware organization read access to apps & services terraform modules
+
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:shopware/*
+claim_pattern:
+  workflow_ref: shopware/*/.github/workflows/*
+
+permissions:
+  contents: read
+
+repositories:
+  - terraform-app-hosting-infra-modules
+  - terraform-app-hosting-ecs-module
+  - terraform-app-hosting-static-web-module


### PR DESCRIPTION
This pull request includes a change to the `.github/chainguard/AppsServicesTerraformModules.sts.yaml` file, which allows repositories in the Shopware organization to have read access to specific Terraform modules.

Access permissions update:

* [`.github/chainguard/AppsServicesTerraformModules.sts.yaml`](diffhunk://#diff-7b190b9d9bb1439cba615f9afc99044413d91ef04cdaed0546dd130452755d05R1-R13): Added read access permissions for repositories in the Shopware organization to the `terraform-app-hosting-infra-modules` and `terraform-app-hosting-ecs-module` repositories.