### PR TITLE
fix: use correct regex for repo matching

### DIFF
--- a/.github/chainguard/AppsServicesTerraformModules.sts.yaml
+++ b/.github/chainguard/AppsServicesTerraformModules.sts.yaml
@@ -1,9 +1,9 @@
 # Allows repositories in shopware organization read access to apps & services terraform modules
 
 issuer: https://token.actions.githubusercontent.com
-subject_pattern: repo:shopware/*
+subject_pattern: repo:shopware/.*
 claim_pattern:
-  workflow_ref: shopware/*/.github/workflows/*
+  workflow_ref: shopware/.*/.github/workflows/.*
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request includes a small change to the `.github/chainguard/AppsServicesTerraformModules.sts.yaml` file. The change fixes the regular expression for `subject_pattern` and `claim_pattern` values.

* [`.github/chainguard/AppsServicesTerraformModules.sts.yaml`](diffhunk://#diff-7b190b9d9bb1439cba615f9afc99044413d91ef04cdaed0546dd130452755d05L4-R6): Updated `subject_pattern` and `claim_pattern` to use `.*` instead of `*` for more inclusive matching.