### PR TITLE
chore: add contents:write permission to SaaS template tokens

### DIFF
--- a/.github/chainguard/ShopwareSaaS.sts.yaml
+++ b/.github/chainguard/ShopwareSaaS.sts.yaml
@@ -4,7 +4,7 @@ issuer: https://token.actions.githubusercontent.com
 subject_pattern: repo:shopware/(saas|Rufus):.*
 
 permissions:
-  contents: read
+  contents: write
 
 repositories:
   - shopware-private


### PR DESCRIPTION
In order to create branches in shopware-private, rufus and commercial, we need `contents:write` permission.