### PR TITLE
chore: add services tags repo to AppsServicesTerraformModules

### DIFF
--- a/.github/chainguard/AppsServicesTerraformModules.sts.yaml
+++ b/.github/chainguard/AppsServicesTerraformModules.sts.yaml
@@ -12,3 +12,4 @@ repositories:
   - terraform-app-hosting-infra-modules
   - terraform-app-hosting-ecs-module
   - terraform-app-hosting-static-web-module
+  - services-aws-tags-module


### PR DESCRIPTION
This pull request includes a small change to the `.github/chainguard/AppsServicesTerraformModules.sts.yaml` file. The change adds the `services-aws-tags-module` to the list of repositories.

* [`.github/chainguard/AppsServicesTerraformModules.sts.yaml`](diffhunk://#diff-7b190b9d9bb1439cba615f9afc99044413d91ef04cdaed0546dd130452755d05R15): Added `services-aws-tags-module` to the list of repositories.