### PR TITLE
feat: add ShopwareSplit sts

### DIFF
--- a/.github/chainguard/ShopwareSplit.sts.yaml
+++ b/.github/chainguard/ShopwareSplit.sts.yaml
@@ -1,0 +1,15 @@
+# Allows shopware to push to administration, core, elasticsearch & storefront
+
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:shopware/shopware:ref:.*
+claim_pattern:
+  workflow_ref: shopware/shopware/.github/workflows/05-prepare-release.yml@.*
+
+permissions:
+  contents: write
+
+repositories:
+  - administration
+  - core
+  - elasticsearch
+  - storefront


### PR DESCRIPTION
Currently we push the administration, core, elasticsearch and storefront splits with a PAT. We should also use `octo-sts`. For this we need this sts rule

Refs: https://github.com/shopware/shopware/issues/9816