### PR TITLE
chore: add write permission for issues to backport token

### DIFF
--- a/.github/chainguard/ShopwareBackport.sts.yaml
+++ b/.github/chainguard/ShopwareBackport.sts.yaml
@@ -7,6 +7,7 @@ permissions:
   contents: write
   pull_requests: write
   workflows: write
+  issues: write
 
 repositories:
   - shopware


### PR DESCRIPTION
This is needed in order to comment/reopen issues as part of the backporting workflow.