### PR TITLE
feat: add PreviewEnvironmentComment

### DIFF
--- a/.github/chainguard/PreviewEnvironmentComment.sts.yaml
+++ b/.github/chainguard/PreviewEnvironmentComment.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:shopware/shopware:.*
+claim_pattern:
+  workflow_ref: shopware/saas/.github/workflows/preview-environment.yml@.*
+
+permissions:
+  pull_requests: write
+
+# Allow access to all repositories of the shopware organization
+repositories: []


### PR DESCRIPTION
As the provided upstream token is only valid for 1 hour and saas sometimes needs longer to deploy and test, we need to use a octo-sts token to comment the upstream PR.