### PR TITLE
feat: allow academy access

### DIFF
--- a/.github/chainguard/ShopwareAcademy.sts.yaml
+++ b/.github/chainguard/ShopwareAcademy.sts.yaml
@@ -1,0 +1,14 @@
+# Allows Shopware Learning Environments in Community Hub be pre-installed with selected premium extensions
+
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:shopware/academy-shopdev-plugin:.*
+
+permissions:
+  contents: read
+
+repositories:
+  - SwagCommercial
+  - SwagCustomizedProducts
+  - SwagPayPal
+  - SwagSocialShopping
+  - swagdigitalsalesrooms

--- a/.github/chainguard/ShopwareAcademy.sts.yaml
+++ b/.github/chainguard/ShopwareAcademy.sts.yaml
@@ -2,7 +2,8 @@
 
 issuer: https://token.actions.githubusercontent.com
 subject_pattern: repo:shopware/academy-shopdev-plugin:.*
-
+claim_pattern:
+  workflow_ref: shopware/academy-shopdev-plugin/.github/workflows/create-template.yml@.*
 permissions:
   contents: read
 


### PR DESCRIPTION
We need to install multiple private extensions into the default template used in Shopware Learning Environments on Community Hub (powered by Shopware Build / ShopDev2). See [PR](https://github.com/shopware/academy-shopdev-plugin/pull/2) and latest [run](https://github.com/shopware/academy-shopdev-plugin/actions/runs/16048607895/job/45285708876#step:4:15).