### PR TITLE
feat: allow saas to read members

### DIFF
--- a/.github/chainguard/ShopwareSaaS.sts.yaml
+++ b/.github/chainguard/ShopwareSaaS.sts.yaml
@@ -5,6 +5,7 @@ subject_pattern: repo:shopware/(saas|Rufus):.*
 
 permissions:
   contents: write
+  members: read
 
 repositories:
   - shopware-private


### PR DESCRIPTION
To get the `organizationVerifiedDomainEmails` we need `members: read` permissions.