### PR TITLE
feat: add cloudfront module to AppsServicesTerraformModules.sts.yaml

### DIFF
--- a/.github/chainguard/AppsServicesTerraformModules.sts.yaml
+++ b/.github/chainguard/AppsServicesTerraformModules.sts.yaml
@@ -13,3 +13,4 @@ repositories:
   - terraform-app-hosting-ecs-module
   - terraform-app-hosting-static-web-module
   - services-aws-tags-module
+  - services-aws-cloudfront-s3-module


### PR DESCRIPTION
This pull request adds the `services-aws-cloudfront-s3-module` to the list of repositories in the `.github/chainguard/AppsServicesTerraformModules.sts.yaml` file to ensure that this module is available with our scope for internal terraform modules for apps & services.