### PR TITLE
fix: allow private repos in hightower-store

### DIFF
--- a/.github/chainguard/ShopwareOperationsHightowerStore.sts.yaml
+++ b/.github/chainguard/ShopwareOperationsHightowerStore.sts.yaml
@@ -1,0 +1,11 @@
+# Allows shopware-operations/hightower-store to pull its required components
+
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:shopware-operations/hightower-store:.*
+
+permissions:
+  contents: read
+
+repositories:
+  - SwagCommercial
+  - SwagCustomizedProducts


### PR DESCRIPTION
We need to install some private extensions in [shopware-operations/hightower-store](https://github.com/shopware-operations/hightower-store) for our GitHub actions to succeed.