### PR TITLE
Update permissions in ShopwareDownstream.sts.yaml

### DIFF
--- a/.github/chainguard/ShopwareDownstream.sts.yaml
+++ b/.github/chainguard/ShopwareDownstream.sts.yaml
@@ -8,7 +8,8 @@ permissions:
   contents: read
   pull_requests: read
   checks: read
-  statuses: read  
+  statuses: read
+  administration: read
 
 repositories:
   - SwagCommercial


### PR DESCRIPTION
Add 'administration' permission to ShopwareDownstream, to allow downstream job to get branch protection rules from downstream repos