### PR TITLE
Update permissions in ShopwareDownstream.sts.yaml

### DIFF
--- a/.github/chainguard/ShopwareDownstream.sts.yaml
+++ b/.github/chainguard/ShopwareDownstream.sts.yaml
@@ -9,7 +9,7 @@ permissions:
   pull_requests: read
   checks: read
   statuses: read
-  administration: read
+  metadata: read
 
 repositories:
   - SwagCommercial


### PR DESCRIPTION
Replaced 'administration' permission with 'metadata' permission.

We don't use old branch protections that need administration permissions but rather branch rules that use metadata permissions: https://docs.github.com/en/rest/repos/rules?apiVersion=2022-11-28#get-rules-for-a-branch