### PR TITLE
Update workflow_ref and modify permissions

### DIFF
--- a/.github/chainguard/ShopwareDownstream.sts.yaml
+++ b/.github/chainguard/ShopwareDownstream.sts.yaml
@@ -1,15 +1,12 @@
 issuer: https://token.actions.githubusercontent.com
 subject_pattern: repo:shopware/shopware(-private)?:.*
 claim_pattern:
-  workflow_ref: shopware/shopware(-private)?/.github/workflows/(downstream|nightly).ya?ml@.*
+  workflow_ref: shopware/shopware(-private)?/.github/workflows/(downstream|nightly|merge-downstreams).ya?ml@.*
 
 permissions:
   actions: write
   contents: read
-  pull_requests: read
-  checks: read
-  statuses: read
-  metadata: read
+  pull_requests: write
 
 repositories:
   - SwagCommercial


### PR DESCRIPTION
Need PR write permission to merge downstreams automatically 

and all checks and status permissions are not needed anymore after relying on mergeable_status flag and not recomputing that on the fly