### PR TITLE
feat: add saas backport permissions

### DIFF
--- a/.github/chainguard/SaaSBackport.sts.yaml
+++ b/.github/chainguard/SaaSBackport.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:shopware/saas:.*
+claim_pattern:
+  workflow_ref: shopware/saas/.github/workflows/backport.ya?ml.*
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write
+
+repositories:
+  - saas


### PR DESCRIPTION
Saas backport (copy pasted from platform) needs it's own permissions,

see failure: https://github.com/shopware/saas/actions/runs/22576385851

SaaS PR to use this token: https://github.com/shopware/saas/pull/388