### PR TITLE
feat: add NexusServiceIntegration STS policy

### DIFF
--- a/.github/chainguard/NexusServiceIntegration.sts.yaml
+++ b/.github/chainguard/NexusServiceIntegration.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: "repo:shopware/nexus-service:.*"
+
+permissions:
+  contents: read
+
+repositories:
+  - service-registry


### PR DESCRIPTION
## Summary
- Adds `NexusServiceIntegration` octo-sts policy granting `shopware/nexus-service` CI read access to `shopware/service-registry`
- Needed for the integration test (PR shopware/nexus-service#69) that builds service-registry from source to test the full Shopware → service-registry → nexus-service registration proxy topology