### PR TITLE
chore: allow saas to access itself through ShopwareSaaS

### DIFF
--- a/.github/chainguard/ShopwareSaaS.sts.yaml
+++ b/.github/chainguard/ShopwareSaaS.sts.yaml
@@ -9,6 +9,7 @@ permissions:
   actions: write
 
 repositories:
+  - saas
   - shopware
   - shopware-private
   - Rufus


### PR DESCRIPTION
As we now also split of saas, it needs to have write permissions to itself.