### PR TITLE
ci(octo-sts): grant access to terraform-streaming-msk-module

### DIFF
--- a/.github/chainguard/AppsServicesTerraformModules.sts.yaml
+++ b/.github/chainguard/AppsServicesTerraformModules.sts.yaml
@@ -12,5 +12,6 @@ repositories:
   - terraform-app-hosting-infra-modules
   - terraform-app-hosting-ecs-module
   - terraform-app-hosting-static-web-module
+  - terraform-streaming-msk-module
   - services-aws-tags-module
   - services-aws-cloudfront-s3-module


### PR DESCRIPTION
## Summary

Adds `terraform-streaming-msk-module` to the `AppsServicesTerraformModules` octo-sts identity so that `databus-conductor` CI can download the private MSK Terraform module during `terraform init`.

**Context**: We are migrating MSK infrastructure ownership from `databus` to `databus-conductor` ([pipe-fiction#599](https://github.com/shopware/pipe-fiction/issues/599)). The conductor's `terraform-plan.yml` workflow uses this identity to authenticate when downloading private Terraform modules, but `terraform-streaming-msk-module` was not included in the allowed repositories list.

**Blocked PR**: https://github.com/shopware/databus-conductor/pull/94