### PR TITLE
feat: adjust access pattern for app-sdk-go repo

### DIFF
--- a/.github/chainguard/GoAppSdk.sts.yaml
+++ b/.github/chainguard/GoAppSdk.sts.yaml
@@ -1,5 +1,7 @@
+# Allows repositories in shopware organization read access to app-sdk-go repository
+
 issuer: https://token.actions.githubusercontent.com
-subject_pattern: "repo:shopware/(nexus-service|spatial-3d-model-pipeline):.*"
+subject_pattern: repo:shopware/.*
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request updates the `.github/chainguard/GoAppSdk.sts.yaml` configuration to broaden repository access permissions. Now, all repositories in the `shopware` organization have read access to the `app-sdk-go` repository instead of just a limited subset.

**Access control changes:**

* Expanded the `subject_pattern` from only matching `nexus-service` and `spatial-3d-model-pipeline` repositories to all repositories under the `shopware` organization, granting them read access to the `app-sdk-go` repository.