### PR TITLE
feat: add repos for shopware.build templates

### DIFF
--- a/.github/chainguard/ShopwareAcademy.sts.yaml
+++ b/.github/chainguard/ShopwareAcademy.sts.yaml
@@ -14,4 +14,3 @@ repositories:
   - SwagSocialShopping
   - swagdigitalsalesrooms
   - SwagCmsExtensions
-  - SwagCustomizedProducts

--- a/.github/chainguard/ShopwareAcademy.sts.yaml
+++ b/.github/chainguard/ShopwareAcademy.sts.yaml
@@ -13,3 +13,5 @@ repositories:
   - SwagPayPal
   - SwagSocialShopping
   - swagdigitalsalesrooms
+  - SwagCmsExtensions
+  - SwagCustomizedProducts


### PR DESCRIPTION
We need to pack 2 more extensions in the template. This PR adds permissions for SwagCmsExtensions ~and SwagCustomizedProducts~.