### PR TITLE
ci: allow read access to terraform-data-dynamodb-cdc-module

### DIFF
--- a/.github/chainguard/AppsServicesTerraformModules.sts.yaml
+++ b/.github/chainguard/AppsServicesTerraformModules.sts.yaml
@@ -15,3 +15,4 @@ repositories:
   - terraform-streaming-msk-module
   - services-aws-tags-module
   - services-aws-cloudfront-s3-module
+  - terraform-data-dynamodb-cdc-module


### PR DESCRIPTION
## Summary

Adds `terraform-data-dynamodb-cdc-module` to the `AppsServicesTerraformModules` octo-sts trust policy so producer-team Terraform pipelines can `terraform init` against it.

The module is the producer-side of the DynamoDB → S3 CDC pipeline (ADR-0007), consumed from service repos like ShopwarePayments. Without this entry, `terraform init` fails with `Repository not found` when the apply action tries to clone the module.

Blocking: shopware/ShopwarePayments#734.

## Test plan

- [ ] After merge, re-run the failing terraform apply job on shopware/ShopwarePayments#734 and confirm `terraform init` resolves the module.