### PR TITLE
[codex] Allow downstream mergeability comments

### DIFF
--- a/.github/chainguard/ShopwareDownstream.sts.yaml
+++ b/.github/chainguard/ShopwareDownstream.sts.yaml
@@ -6,6 +6,7 @@ claim_pattern:
 permissions:
   actions: write
   contents: write
+  issues: write
   pull_requests: read
 
 repositories:


### PR DESCRIPTION
## What changed
- Grant `issues: write` to the `ShopwareDownstream` STS policy.

## Why
The downstream mergeability workflow comments on blocked downstream PRs. PR comments use GitHub issue comment APIs, so the STS token needs issue write access on `SwagCommercial` and `Rufus`.

## Validation
- Policy diff is limited to one permission line.

## Companion PR
- Supports https://github.com/shopware/shopware/pull/17562.
