### PR TITLE
[codex] Allow downstream PR comments

### DIFF
--- a/.github/chainguard/ShopwareDownstream.sts.yaml
+++ b/.github/chainguard/ShopwareDownstream.sts.yaml
@@ -7,7 +7,7 @@ permissions:
   actions: write
   contents: write
   issues: write
-  pull_requests: read
+  pull_requests: write
 
 repositories:
   - SwagCommercial


### PR DESCRIPTION
## What changed
- Change `ShopwareDownstream` from `pull_requests: read` to `pull_requests: write`.

## Why
The downstream mergeability workflow can now detect blocked downstream PRs and comment on the platform PR, but comments on the downstream PRs still return `403 Resource not accessible by integration` with only `issues: write` and `pull_requests: read`.

## Validation
- Failing run shows downstream comment `POST /issues/.../comments` still gets 403 after `issues: write` was merged.
- Platform comments started working once the workflow token had `PullRequests: write`.
