### PR TITLE
feat: add data-platform to apps & services repos

### DIFF
--- a/.github/chainguard/AppsServicesTerraformModules.sts.yaml
+++ b/.github/chainguard/AppsServicesTerraformModules.sts.yaml
@@ -17,3 +17,4 @@ repositories:
   - services-aws-cloudfront-s3-module
   - terraform-data-dynamodb-cdc-module
   - terraform-data-mysql-cdc-module
+  - data-platform


### PR DESCRIPTION
This pull request makes a small update to the `.github/chainguard/AppsServicesTerraformModules.sts.yaml` file, adding the `data-platform` repository to the list of allowed repositories to read.

This change is required for the `terraform-app-hosting-infrastructure` repo to access the `data-platform/modules` for the `cdc-cross-account-provisioning-role` module.