### PR TITLE
feat: add nexus-connector-sandboxes to pipe-fiction docs-sync trust policies

### DIFF
--- a/.github/chainguard/PipeFictionDispatch.sts.yaml
+++ b/.github/chainguard/PipeFictionDispatch.sts.yaml
@@ -1,9 +1,9 @@
 # Allows Nexus child repositories to dispatch docs-sync events to pipe-fiction
 
 issuer: https://token.actions.githubusercontent.com
-subject_pattern: repo:shopware/(databus|databus-conductor|nexus-e2e|nexus-workflow-builder|nexus-service|nexus-contracts):.*
+subject_pattern: repo:shopware/(databus|databus-conductor|nexus-connector-sandboxes|nexus-e2e|nexus-workflow-builder|nexus-service|nexus-contracts):.*
 claim_pattern:
-  workflow_ref: shopware/(databus|databus-conductor|nexus-e2e|nexus-workflow-builder|nexus-service|nexus-contracts)/.github/workflows/request-pipe-fiction-doc-sync\.yml@.*
+  workflow_ref: shopware/(databus|databus-conductor|nexus-connector-sandboxes|nexus-e2e|nexus-workflow-builder|nexus-service|nexus-contracts)/.github/workflows/request-pipe-fiction-doc-sync\.yml@.*
 
 permissions:
   contents: write

--- a/.github/chainguard/PipeFictionDocsSyncSourceRead.sts.yaml
+++ b/.github/chainguard/PipeFictionDocsSyncSourceRead.sts.yaml
@@ -12,6 +12,7 @@ permissions:
 repositories:
   - databus
   - databus-conductor
+  - nexus-connector-sandboxes
   - nexus-contracts
   - nexus-e2e
   - nexus-service


### PR DESCRIPTION
## What

Adds `shopware/nexus-connector-sandboxes` (QA/E2E sandbox infrastructure for self-hostable Nexus connectors, see [pipe-fiction#1068](https://github.com/shopware/pipe-fiction/issues/1068)) to the two octo-sts trust policies used by the pipe-fiction docs-sync flow:

- **PipeFictionDispatch** — so the repo's `request-pipe-fiction-doc-sync.yml` (same workflow as in the other six Nexus repos) can mint a dispatch token. Currently fails with:
  > trust policy: subject "repo:shopware/nexus-connector-sandboxes:pull_request" did not match pattern
  ([failing run](https://github.com/shopware/nexus-connector-sandboxes/actions/runs/28664381777))
- **PipeFictionDocsSyncSourceRead** — so pipe-fiction's `docs-sync-on-merge.yml` can read the merged source PRs from the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)