### PR TITLE
fix: add pull_requests:write to ShopwareSaaS for PR label updates

### DIFF
--- a/.github/chainguard/ShopwareSaaS.sts.yaml
+++ b/.github/chainguard/ShopwareSaaS.sts.yaml
@@ -8,6 +8,7 @@ permissions:
   members: read
   actions: write
   issues: write
+  pull_requests: write
 
 repositories:
   - saas


### PR DESCRIPTION
The "Move milestone label on open PRs to next version" job in shopware/saas (Split off release branches workflow) fails with 403 when removing milestone labels from PRs in shopware/shopware:

```
DELETE /repos/shopware/shopware/issues/15471/labels/milestone%2F6.7.13.0
→ 403 Resource not accessible by integration
x-accepted-github-permissions: issues=write; pull_requests=write
```

`issues: write` alone (added earlier today) is not sufficient: the label endpoints live under the issues API, but for **pull request** targets GitHub Apps need the `pull_requests` permission. Confirmed empirically — the 13:47 run failed with a fresh token that already had `issues: write` ([failing job](https://github.com/shopware/saas/actions/runs/29747685795/job/88369823957)).

`issues: write` stays in place for milestone labels on actual issues.