### PR TITLE
fix(octo-sts): point AppsServicesTerraformModules trust at renamed terraform-data-sql-cdc-module

### DIFF
--- a/.github/chainguard/AppsServicesTerraformModules.sts.yaml
+++ b/.github/chainguard/AppsServicesTerraformModules.sts.yaml
@@ -16,5 +16,5 @@ repositories:
   - services-aws-tags-module
   - services-aws-cloudfront-s3-module
   - terraform-data-dynamodb-cdc-module
-  - terraform-data-mysql-cdc-module
+  - terraform-data-sql-cdc-module
   - data-platform


### PR DESCRIPTION
## Urgent — unblocks all shopware/data-platform terraform CI

The CDC-via-DMS module repo was renamed `terraform-data-mysql-cdc-module` → `terraform-data-sql-cdc-module` (org#722). This trust policy's `repositories:` list still named the old repo.

octo-sts mints a **GitHub App installation token scoped to the listed repositories**; a repo name that no longer resolves makes token creation return **422 UnprocessableEntity**, which surfaces as **403 on the octo-sts exchange**:

```
octo-sts.dev/sts/exchange ... status: 403, {"message":"token exchange failure (StatusUnprocessableEntity)"}
```

That exchange runs in **every** data-platform terraform job (plan + apply, staging + production, plus static.yml), so the stale name broke **all** of data-platform's CI — not just the stage that consumes the module.

Fix: rename the entry to `terraform-data-sql-cdc-module`. One line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)