### PR TITLE
feat(ci): allow commercial downstream callbacks

### DIFF
--- a/.github/chainguard/CommercialDownstreamCallback.sts.yaml
+++ b/.github/chainguard/CommercialDownstreamCallback.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:shopware/SwagCommercial:.*
+claim_pattern:
+  workflow_ref: shopware/SwagCommercial/.github/workflows/downstream.ya?ml@.*
+
+permissions:
+  checks: write
+
+repositories:
+  - shopware


### PR DESCRIPTION
## Why

Commercial needs to complete the pending Platform `Commercial` check after its downstream workflow ends.

## What

Add a dedicated STS identity restricted to `shopware/SwagCommercial`'s `downstream.yaml`. It has only `checks: write` and can act only on the Platform repository.

## Dependency

Required by [shopware/SwagCommercial#3341](https://github.com/shopware/SwagCommercial/pull/3341) and [shopware/shopware#18549](https://github.com/shopware/shopware/pull/18549).

## Validation

Parsed the policy as YAML and ran `actionlint` on the Commercial workflow.